### PR TITLE
Client Fixes

### DIFF
--- a/Clients/Nuages_Cli/app/cmd.js
+++ b/Clients/Nuages_Cli/app/cmd.js
@@ -46,7 +46,7 @@ nuages.commands["!implants"]= new Command()
     }
     else if(cmdObj.kill) {
         if(cmdObj.all) {
-            nuages.implantService.find({$limit:500}).then(implants => {
+            nuages.implantService.find({query: {$limit: 200}}).then(implants => {
                 for(var i=0; i< implants.data.length; i++){
                     shortID = implants.data[i]._id.substring(0,6);
                     nuages.createJob(shortID, {type: "exit", options: {}});
@@ -63,7 +63,7 @@ nuages.commands["!implants"]= new Command()
             tmpconfig[cmdObj.configure] = cmdObj.value
         }
         if(cmdObj.all) {
-            nuages.implantService.find({$limit:500}).then(implants => {
+            nuages.implantService.find({query: {$limit: 200}}).then(implants => {
                 for(var i=0; i< implants.data.length; i++){
                     shortID = implants.data[i]._id.substring(0,6);
                     nuages.createJob(shortID, {type: "configure", options: {config:tmpconfig}});

--- a/Clients/Nuages_Cli/app/nuagesAPI.js
+++ b/Clients/Nuages_Cli/app/nuagesAPI.js
@@ -67,7 +67,7 @@ nuages.vars.globalOptions = {
             description: "The implant to interact with"
         },
         timeout:{
-            value: 60,
+            value: 1,
             description: "The job timeout, in minutes"
         },
         buffersize:{

--- a/Clients/Nuages_Cli/app/nuagesAPI.js
+++ b/Clients/Nuages_Cli/app/nuagesAPI.js
@@ -23,7 +23,8 @@ const socket = io(nuages.cli_options.url);
 const app = feathers();
 
 app.configure(feathers.authentication({}));
-app.configure(feathers.socketio(socket, { timeout: 10000 }));
+// 5 minute socket timeout
+app.configure(feathers.socketio(socket, { timeout: 300000 }));
 
 nuages.implantService = app.service('/implants');
 nuages.jobService = app.service('/jobs');
@@ -66,7 +67,7 @@ nuages.vars.globalOptions = {
             description: "The implant to interact with"
         },
         timeout:{
-            value: 1,
+            value: 60,
             description: "The job timeout, in minutes"
         },
         buffersize:{

--- a/Clients/Nuages_WebCli/app/nuagesAPI.js
+++ b/Clients/Nuages_WebCli/app/nuagesAPI.js
@@ -38,7 +38,7 @@ nuages.vars.globalOptions = {
         implant: 0,
         //path : ".",
         chunksize: 2400000,
-        timeout: "60",
+        timeout: "1",
 };
     
 nuages.vars.moduleOptions = {};

--- a/Clients/Nuages_WebCli/app/nuagesAPI.js
+++ b/Clients/Nuages_WebCli/app/nuagesAPI.js
@@ -38,7 +38,7 @@ nuages.vars.globalOptions = {
         implant: 0,
         //path : ".",
         chunksize: 2400000,
-        timeout: "1",
+        timeout: "60",
 };
     
 nuages.vars.moduleOptions = {};


### PR DESCRIPTION
This pull request at the moment features a few fixes for the clients. Operators were experiencing the inability to kill all of the implants. When I debugged the code below, only the first 10 results were being returned:

`nuages.implantService.find({$limit:500}).then(implants => {`

When I changed it to what you see below, I started getting all of the implants back:

`nuages.implantService.find({query: {$limit: 200}}).then(implants => {`

Among the fixes is an increased job timeout. I'm not exactly sure what you are using the C2 for or have used it for in the past, but a 1 minute job timeout is really short, and a lot of our commands were returning a timed out status until we increased the job timeout. I also increased a hardcoded socket timeout in the CLI client as it was causing the MongoDB connection to terminate prematurely before a login could take place in certain instances.

And thank you for the great work!